### PR TITLE
add llm_criteria_jury_gpt_gemini_high

### DIFF
--- a/src/recursiveai/benchmark/_internal/_evaluators/__init__.py
+++ b/src/recursiveai/benchmark/_internal/_evaluators/__init__.py
@@ -70,5 +70,7 @@ def get_criteria_evaluator(evaluator: str) -> CriteriaEvaluator:
             return LLMCriteriaJuryEvaluator(
                 judge_models=[GPT_3_5_TURBO, CLAUDE_3_HAIKU, GEMINI_1_5_FLASH]
             )
+        case "llm_criteria_jury_gpt_gemini_high":
+            return LLMCriteriaJuryEvaluator(judge_models=[GPT_4_O, GEMINI_1_5_PRO])
         case _:
             return LLMCriteriaJudgeEvaluator(model=GPT_4_O)

--- a/src/recursiveai/benchmark/api/benchmark_evaluator.py
+++ b/src/recursiveai/benchmark/api/benchmark_evaluator.py
@@ -21,6 +21,8 @@ class Evaluator(str, Enum):
 
     LLM_CRITERIA_JUDGE_GPT_4_0 = "llm_criteria_judge_gpt-4o"
 
+    LLM_CRITERIA_JURY_GPT_GEMINI_HIGH = "llm_criteria_jury_gpt_gemini_high"
+
     LLM_CRITERIA_JURY_GPT_CLAUDE_GEMINI_HIGH = (
         "llm_criteria_jury_gpt_claude_gemini_high"
     )


### PR DESCRIPTION
This pull request simply adds one new CriteriaEvaluator. This is an option with only OpenAI's GPT-4o and Google's Gemini-1.5-pro. It is useful when Anthropic models are not available. 

It can be tested by setting an OPENAI_API_KEY, GOOGLE_API_KEY, and then running the `python src/examples/criteria_evaluation_agent.py`

- ~[ ] Checked the work against _all_ of the ticket requirements~
- ~[ ] CHANGELOG updated~
- [x] Formatter has been run against all changed files
- [x] All changed files have been added correctly
- ~[ ] Appropriate unit tests and integration tests have been added~
- ~[ ] All tests are passing~
- [x] Ad hoc testing has been done
