### PR TITLE
Adds GPT4o-mini as an option for CriteriaEvaluation

### DIFF
--- a/src/recursiveai/benchmark/_internal/_evaluators/__init__.py
+++ b/src/recursiveai/benchmark/_internal/_evaluators/__init__.py
@@ -13,7 +13,7 @@ from .._llm._openai_gpt_model import (
     GPT_3_5_TURBO,
     GPT_4_O,
     GPT_4_TURBO_PREVIEW,
-    GPT_4_O_mini,
+    GPT_4_O_MINI,
 )
 from ._happy import HappyEvaluator
 from ._llm_criteria_judge import LLMCriteriaJudgeEvaluator
@@ -67,8 +67,8 @@ def get_criteria_evaluator(evaluator: str) -> CriteriaEvaluator:
     match (evaluator):
         case "llm_criteria_judge_gpt-4o":
             return LLMCriteriaJudgeEvaluator(model=GPT_4_O)
-        case "llm_criteria_judge_gpt-4o_mini":
-            return LLMCriteriaJudgeEvaluator(model=GPT_4_O_mini)
+        case "llm_criteria_judge_gpt-4o-mini":
+            return LLMCriteriaJudgeEvaluator(model=GPT_4_O_MINI)
         case "llm_criteria_jury_gpt_claude_gemini_high":
             return LLMCriteriaJuryEvaluator(
                 judge_models=[GPT_4_O, CLAUDE_3_5_SONNET, GEMINI_1_5_PRO]

--- a/src/recursiveai/benchmark/_internal/_evaluators/__init__.py
+++ b/src/recursiveai/benchmark/_internal/_evaluators/__init__.py
@@ -9,7 +9,12 @@ from .._llm._anthropic_claude_model import (
 )
 from .._llm._azure_openai_gpt_model import AZURE_GPT
 from .._llm._google_gemini_model import GEMINI_1_5_FLASH, GEMINI_1_5_PRO
-from .._llm._openai_gpt_model import GPT_3_5_TURBO, GPT_4_O, GPT_4_TURBO_PREVIEW, GPT_4_O_mini
+from .._llm._openai_gpt_model import (
+    GPT_3_5_TURBO,
+    GPT_4_O,
+    GPT_4_TURBO_PREVIEW,
+    GPT_4_O_mini,
+)
 from ._happy import HappyEvaluator
 from ._llm_criteria_judge import LLMCriteriaJudgeEvaluator
 from ._llm_criteria_jury import LLMCriteriaJuryEvaluator

--- a/src/recursiveai/benchmark/_internal/_evaluators/__init__.py
+++ b/src/recursiveai/benchmark/_internal/_evaluators/__init__.py
@@ -9,7 +9,7 @@ from .._llm._anthropic_claude_model import (
 )
 from .._llm._azure_openai_gpt_model import AZURE_GPT
 from .._llm._google_gemini_model import GEMINI_1_5_FLASH, GEMINI_1_5_PRO
-from .._llm._openai_gpt_model import GPT_3_5_TURBO, GPT_4_O, GPT_4_TURBO_PREVIEW
+from .._llm._openai_gpt_model import GPT_3_5_TURBO, GPT_4_O, GPT_4_TURBO_PREVIEW, GPT_4_O_mini
 from ._happy import HappyEvaluator
 from ._llm_criteria_judge import LLMCriteriaJudgeEvaluator
 from ._llm_criteria_jury import LLMCriteriaJuryEvaluator
@@ -62,6 +62,8 @@ def get_criteria_evaluator(evaluator: str) -> CriteriaEvaluator:
     match (evaluator):
         case "llm_criteria_judge_gpt-4o":
             return LLMCriteriaJudgeEvaluator(model=GPT_4_O)
+        case "llm_criteria_judge_gpt-4o_mini":
+            return LLMCriteriaJudgeEvaluator(model=GPT_4_O_mini)
         case "llm_criteria_jury_gpt_claude_gemini_high":
             return LLMCriteriaJuryEvaluator(
                 judge_models=[GPT_4_O, CLAUDE_3_5_SONNET, GEMINI_1_5_PRO]

--- a/src/recursiveai/benchmark/_internal/_llm/_openai_gpt_model.py
+++ b/src/recursiveai/benchmark/_internal/_llm/_openai_gpt_model.py
@@ -76,3 +76,4 @@ GPT_4_TURBO_PREVIEW = GPTX(
     name="gpt-4-turbo-preview", context_window=128000, output_window=4096
 )
 GPT_4_O = GPTX(name="gpt-4o", context_window=128000, output_window=4096)
+GPT_4_O_mini = GPTX(name="gpt-4o-mini", context_window=128000, output_window=4096)

--- a/src/recursiveai/benchmark/_internal/_llm/_openai_gpt_model.py
+++ b/src/recursiveai/benchmark/_internal/_llm/_openai_gpt_model.py
@@ -76,4 +76,4 @@ GPT_4_TURBO_PREVIEW = GPTX(
     name="gpt-4-turbo-preview", context_window=128000, output_window=4096
 )
 GPT_4_O = GPTX(name="gpt-4o", context_window=128000, output_window=4096)
-GPT_4_O_mini = GPTX(name="gpt-4o-mini", context_window=128000, output_window=4096)
+GPT_4_O_MINI = GPTX(name="gpt-4o-mini", context_window=128000, output_window=16384)

--- a/src/recursiveai/benchmark/api/benchmark_evaluator.py
+++ b/src/recursiveai/benchmark/api/benchmark_evaluator.py
@@ -20,6 +20,7 @@ class Evaluator(str, Enum):
     LLM_JURY_GPT_CLAUDE_GEMINI_LOW = "llm_jury_gpt_claude_gemini_low"
 
     LLM_CRITERIA_JUDGE_GPT_4_0 = "llm_criteria_judge_gpt-4o"
+    LLM_CRITERIA_JUDGE_GPT_4_O_MINI = "llm_criteria_judge_gpt-4o_mini"
 
     LLM_CRITERIA_JURY_GPT_GEMINI_HIGH = "llm_criteria_jury_gpt_gemini_high"
 

--- a/src/recursiveai/benchmark/api/benchmark_evaluator.py
+++ b/src/recursiveai/benchmark/api/benchmark_evaluator.py
@@ -20,7 +20,7 @@ class Evaluator(str, Enum):
     LLM_JURY_GPT_CLAUDE_GEMINI_LOW = "llm_jury_gpt_claude_gemini_low"
 
     LLM_CRITERIA_JUDGE_GPT_4_0 = "llm_criteria_judge_gpt-4o"
-    LLM_CRITERIA_JUDGE_GPT_4_O_MINI = "llm_criteria_judge_gpt-4o_mini"
+    LLM_CRITERIA_JUDGE_GPT_4_O_MINI = "llm_criteria_judge_gpt-4o-mini"
 
     LLM_CRITERIA_JURY_GPT_GEMINI_HIGH = "llm_criteria_jury_gpt_gemini_high"
 

--- a/src/tests/internal/test_openai.py
+++ b/src/tests/internal/test_openai.py
@@ -10,6 +10,7 @@ from recursiveai.benchmark._internal._llm._openai_gpt_model import (
     GPT_3_5_TURBO,
     GPT_4_O,
     GPT_4_TURBO_PREVIEW,
+    GPT_4_O_MINI,
     GPTX,
 )
 
@@ -39,6 +40,10 @@ def test_gpt_4o_context_window():
     assert GPT_4_O.context_window == 128000
 
 
+def test_gpt_4o_mini_context_window():
+    assert GPT_4_O_MINI.context_window == 128000
+
+
 def test_no_output_window(mock_model: GPTX):
     assert mock_model.context_window == mock_model.output_window
 
@@ -47,8 +52,8 @@ def test_no_output_window(mock_model: GPTX):
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.parametrize(
     argnames="model",
-    argvalues=[GPT_3_5_TURBO, GPT_4_TURBO_PREVIEW, GPT_4_O],
-    ids=[GPT_3_5_TURBO.name, GPT_4_TURBO_PREVIEW.name, GPT_4_O.name],
+    argvalues=[GPT_3_5_TURBO, GPT_4_TURBO_PREVIEW, GPT_4_O, GPT_4_O_MINI],
+    ids=[GPT_3_5_TURBO.name, GPT_4_TURBO_PREVIEW.name, GPT_4_O.name, GPT_4_O_MINI.name],
 )
 async def test_async_chat_completion_success(model: GPTX):
     chat = [


### PR DESCRIPTION
This pull request adds GPT4o-mini as an option for criteria evaluation (to have the cheapest models available)

- ~[ ] Checked the work against _all_ of the ticket requirements~
- ~[ ] CHANGELOG updated~
- [x] Formatter has been run against all changed files
- [x] All changed files have been added correctly
- ~[ ] Appropriate unit tests and integration tests have been added~
- ~[ ] All tests are passing~
- [x] Ad hoc testing has been done