### PR TITLE
Add support for gemini 2.0 flash, upgrade versions of langchain depen…

### DIFF
--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -1,7 +1,8 @@
 # LangChain
-langchain==0.2.2
-langchain-openai==0.1.8
-langchain-community==0.2.3
+langchain==0.3.25
+langchain-community==0.3.24
+langchain-openai==0.3.19
+langchain-google-genai==2.0.10
 pypdf==4.2.0
 docx2txt==0.8
 faiss-cpu==1.7.4

--- a/src/recursiveai/benchmark/_internal/_evaluators/__init__.py
+++ b/src/recursiveai/benchmark/_internal/_evaluators/__init__.py
@@ -8,12 +8,16 @@ from .._llm._anthropic_claude_model import (
     CLAUDE_3_OPUS,
 )
 from .._llm._azure_openai_gpt_model import AZURE_GPT
-from .._llm._google_gemini_model import GEMINI_1_5_FLASH, GEMINI_1_5_PRO
+from .._llm._google_gemini_model import (
+    GEMINI_1_5_FLASH,
+    GEMINI_1_5_PRO,
+    GEMINI_2_0_FLASH,
+)
 from .._llm._openai_gpt_model import (
     GPT_3_5_TURBO,
     GPT_4_O,
-    GPT_4_TURBO_PREVIEW,
     GPT_4_O_MINI,
+    GPT_4_TURBO_PREVIEW,
 )
 from ._happy import HappyEvaluator
 from ._llm_criteria_judge import LLMCriteriaJudgeEvaluator
@@ -44,6 +48,8 @@ def get_evaluator(evaluator: str) -> BenchmarkEvaluator:
             return LLMJudgeEvaluator(model=GEMINI_1_5_FLASH)
         case "llm_judge_gemini-1.5-pro":
             return LLMJudgeEvaluator(model=GEMINI_1_5_PRO)
+        case "llm_judge_gemini-2.0-flash":
+            return LLMJudgeEvaluator(model=GEMINI_2_0_FLASH)
         case "llm_judge_azure-gpt":
             return LLMJudgeEvaluator(model=AZURE_GPT)
         case "llm_jury_gpt_claude_gemini_high":

--- a/src/recursiveai/benchmark/_internal/_llm/_google_gemini_model.py
+++ b/src/recursiveai/benchmark/_internal/_llm/_google_gemini_model.py
@@ -111,3 +111,6 @@ GEMINI_1_5_FLASH = GoogleGemini(
 GEMINI_1_5_PRO = GoogleGemini(
     name="gemini-1.5-pro", context_window=1048576, output_window=8192
 )
+GEMINI_2_0_FLASH = GoogleGemini(
+    name="gemini-2.0-flash", context_window=1048576, output_window=8192
+)

--- a/src/recursiveai/benchmark/api/benchmark_evaluator.py
+++ b/src/recursiveai/benchmark/api/benchmark_evaluator.py
@@ -14,6 +14,7 @@ class Evaluator(str, Enum):
     LLM_JUDGE_CLAUDE_3_HAIKU = "llm_judge_claude-3-haiku"
     LLM_JUDGE_GEMINI_1_5_FLASH = "llm_judge_gemini-1.5-flash"
     LLM_JUDGE_GEMINI_1_5_PRO = "llm_judge_gemini-1.5-pro"
+    LLM_JUDGE_GEMINI_2_0_FLASH = "llm_judge_gemini-2.0-flash"
     LLM_JUDGE_AZURE_GPT = "llm_judge_azure-gpt"
 
     LLM_JURY_GPT_CLAUDE_GEMINI_HIGH = "llm_jury_gpt_claude_gemini_high"

--- a/src/tests/internal/test_google.py
+++ b/src/tests/internal/test_google.py
@@ -8,6 +8,7 @@ import pytest
 from recursiveai.benchmark._internal._llm._google_gemini_model import (
     GEMINI_1_5_FLASH,
     GEMINI_1_5_PRO,
+    GEMINI_2_0_FLASH,
     GoogleGemini,
 )
 from recursiveai.benchmark._internal._llm._llm_model import ChatMessage
@@ -42,8 +43,8 @@ def test_no_output_window(mock_model: GoogleGemini):
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.parametrize(
     argnames="model",
-    argvalues=[GEMINI_1_5_FLASH, GEMINI_1_5_PRO],
-    ids=[GEMINI_1_5_FLASH.name, GEMINI_1_5_PRO.name],
+    argvalues=[GEMINI_1_5_FLASH, GEMINI_1_5_PRO, GEMINI_2_0_FLASH],
+    ids=[GEMINI_1_5_FLASH.name, GEMINI_1_5_PRO.name, GEMINI_2_0_FLASH.name],
 )
 async def test_async_chat_completion_success(model: GoogleGemini):
     chat = [


### PR DESCRIPTION
This pull request:

1. Adds support for [Gemini 2.0 flash](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-0-flash).
1. Upgrades the langchain versions so they don't conflict with the latest langchain_google_genai

- [ ] Checked the work against _all_ of the ticket requirements
- [ ] CHANGELOG updated
- [ ] Formatter has been run against all changed files
- [ ] All changed files have been added correctly
- [ ] Appropriate unit tests and integration tests have been added
- [ ] All tests are passing
- [ ] Ad hoc testing has been done
- [ ] Affected docs have been updated
- [ ] Tickets created for any TODOs
- [ ] All licenses have been checked and confirmed for commercial use